### PR TITLE
DBOSMaxStepRetriesExceeded Includes Exceptions

### DIFF
--- a/dbos/_core.py
+++ b/dbos/_core.py
@@ -1123,7 +1123,7 @@ def decorate_step(
                 stepOutcome = stepOutcome.retry(
                     max_attempts,
                     on_exception,
-                    lambda i: DBOSMaxStepRetriesExceeded(func.__name__, i),
+                    lambda i, e: DBOSMaxStepRetriesExceeded(func.__name__, i, e),
                 )
 
             outcome = (

--- a/dbos/_error.py
+++ b/dbos/_error.py
@@ -150,9 +150,12 @@ class DBOSNotAuthorizedError(DBOSException):
 class DBOSMaxStepRetriesExceeded(DBOSException):
     """Exception raised when a step was retried the maximimum number of times without success."""
 
-    def __init__(self, step_name: str, max_retries: int) -> None:
+    def __init__(
+        self, step_name: str, max_retries: int, errors: list[BaseException]
+    ) -> None:
         self.step_name = step_name
         self.max_retries = max_retries
+        self.errors = errors
         super().__init__(
             f"Step {step_name} has exceeded its maximum of {max_retries} retries",
             dbos_error_code=DBOSErrorCode.MaxStepRetriesExceeded.value,
@@ -160,7 +163,7 @@ class DBOSMaxStepRetriesExceeded(DBOSException):
 
     def __reduce__(self) -> Any:
         # Tell jsonpickle how to reconstruct this object
-        return (self.__class__, (self.step_name, self.max_retries))
+        return (self.__class__, (self.step_name, self.max_retries, self.errors))
 
 
 class DBOSConflictingRegistrationError(DBOSException):

--- a/dbos/_error.py
+++ b/dbos/_error.py
@@ -151,7 +151,7 @@ class DBOSMaxStepRetriesExceeded(DBOSException):
     """Exception raised when a step was retried the maximimum number of times without success."""
 
     def __init__(
-        self, step_name: str, max_retries: int, errors: list[BaseException]
+        self, step_name: str, max_retries: int, errors: list[Exception]
     ) -> None:
         self.step_name = step_name
         self.max_retries = max_retries

--- a/dbos/_outcome.py
+++ b/dbos/_outcome.py
@@ -37,7 +37,7 @@ class Outcome(Protocol[T]):
         self,
         attempts: int,
         on_exception: Callable[[int, BaseException], float],
-        exceeded_retries: Callable[[int, list[BaseException]], BaseException],
+        exceeded_retries: Callable[[int, list[Exception]], Exception],
     ) -> "Outcome[T]": ...
 
     def intercept(
@@ -96,9 +96,9 @@ class Immediate(Outcome[T]):
         func: Callable[[], T],
         attempts: int,
         on_exception: Callable[[int, BaseException], float],
-        exceeded_retries: Callable[[int, list[BaseException]], BaseException],
+        exceeded_retries: Callable[[int, list[Exception]], Exception],
     ) -> T:
-        errors: list[BaseException] = []
+        errors: list[Exception] = []
         for i in range(attempts):
             try:
                 with EnterDBOSStepRetry(i, attempts):
@@ -114,7 +114,7 @@ class Immediate(Outcome[T]):
         self,
         attempts: int,
         on_exception: Callable[[int, BaseException], float],
-        exceeded_retries: Callable[[int, list[BaseException]], BaseException],
+        exceeded_retries: Callable[[int, list[Exception]], Exception],
     ) -> "Immediate[T]":
         assert attempts > 0
         return Immediate[T](
@@ -185,9 +185,9 @@ class Pending(Outcome[T]):
         func: Callable[[], Coroutine[Any, Any, T]],
         attempts: int,
         on_exception: Callable[[int, BaseException], float],
-        exceeded_retries: Callable[[int, list[BaseException]], BaseException],
+        exceeded_retries: Callable[[int, list[Exception]], Exception],
     ) -> T:
-        errors: list[BaseException] = []
+        errors: list[Exception] = []
         for i in range(attempts):
             try:
                 with EnterDBOSStepRetry(i, attempts):
@@ -203,7 +203,7 @@ class Pending(Outcome[T]):
         self,
         attempts: int,
         on_exception: Callable[[int, BaseException], float],
-        exceeded_retries: Callable[[int, list[BaseException]], BaseException],
+        exceeded_retries: Callable[[int, list[Exception]], Exception],
     ) -> "Pending[T]":
         assert attempts > 0
         return Pending[T](

--- a/tests/test_failures.py
+++ b/tests/test_failures.py
@@ -448,10 +448,11 @@ def test_error_serialization() -> None:
     # Verify that each exception that can be thrown in a workflow
     # is serializable and deserializable
     # DBOSMaxStepRetriesExceeded
-    e: Exception = DBOSMaxStepRetriesExceeded("step", 1)
+    e: Exception = DBOSMaxStepRetriesExceeded("step", 1, [Exception()])
     d = deserialize_exception(serialize_exception(e))
     assert isinstance(d, DBOSMaxStepRetriesExceeded)
     assert str(d) == str(e)
+    assert isinstance(d.errors[0], Exception)
     # DBOSNotAuthorizedError
     e = DBOSNotAuthorizedError("no")
     d = deserialize_exception(serialize_exception(e))

--- a/tests/test_failures.py
+++ b/tests/test_failures.py
@@ -332,6 +332,11 @@ def test_step_retries(dbos: DBOS) -> None:
         failing_step()
     assert error_message in str(excinfo.value)
     assert step_counter == max_attempts
+    assert len(excinfo.value.errors) == max_attempts
+    for error in excinfo.value.errors:
+        assert isinstance(error, Exception)
+        assert error
+        assert "fail" in str(error)
 
     # Test calling the workflow
     step_counter = 0

--- a/tests/test_outcome.py
+++ b/tests/test_outcome.py
@@ -56,7 +56,7 @@ def test_immediate_retry() -> None:
         raise Exception("Error")
 
     o1 = Outcome[int].make(raiser)
-    o2 = o1.retry(3, lambda i, e: 0.1, lambda i: ExceededRetries())
+    o2 = o1.retry(3, lambda i, e: 0.1, lambda i, e: ExceededRetries())
 
     assert isinstance(o2, Immediate)
     with pytest.raises(ExceededRetries):
@@ -105,7 +105,7 @@ async def test_pending_retry() -> None:
         raise Exception("Error")
 
     o1 = Outcome[int].make(raiser)
-    o2 = o1.retry(3, lambda i, e: 0.1, lambda i: ExceededRetries())
+    o2 = o1.retry(3, lambda i, e: 0.1, lambda i, e: ExceededRetries())
 
     assert isinstance(o2, Pending)
     with pytest.raises(ExceededRetries):


### PR DESCRIPTION
If a step throws `DBOSMaxStepRetriesExceeded` after exceeding its maximum retries, the exception now includes all errors the step encountered.